### PR TITLE
Make tests pass

### DIFF
--- a/no-brainer/private/build-arity-table.rkt
+++ b/no-brainer/private/build-arity-table.rkt
@@ -32,6 +32,8 @@
     (kernel-syntax-case stx #f
       [(#%provide . provide-specs)
        null]
+      [(module . body)
+       null]
       [else-stx
        (general-top-level-expr-iterator stx)]))
   
@@ -42,9 +44,6 @@
          (cond [(= (length var-list) 1) (expr-iterator #'expr (car var-list))]
                [else (expr-iterator #'expr #f)]))]
       [(define-syntaxes (var ...) expr)
-       null]
-      ;; untested:
-      [(define-values-for-syntax (id ...) expr)
        null]
       ;; untested:
       [(#%require . require-specs)

--- a/no-brainer/private/check-program.rkt
+++ b/no-brainer/private/check-program.rkt
@@ -167,9 +167,9 @@
         (make-regular-top-result (expr-iterator #'expr table)))]
       [(define-syntaxes (var ...) expr)
        empty-top-result]
-      [(define-values-for-syntax (id ...) expr)
-       empty-top-result]
       [(#%require . require-specs)
+       empty-top-result]
+      [(module . body)
        empty-top-result]
       [else
        (make-regular-top-result (expr-iterator stx table))]))

--- a/no-brainer/private/tests.rkt
+++ b/no-brainer/private/tests.rkt
@@ -143,7 +143,7 @@
 (check-program-test `() `(begin 3 4))
 (let* ([stx (expand (datum->syntax #'here `(module foo scheme (define (h x) (h x)))))]
        [id (syntax-case stx ()
-             [(mod dc1 dc2 (mod-beg (define-values (id) . dc3)))
+             [(mod dc1 dc2 (mod-beg mcr (define-values (id) . dc3)))
               #'id])]
        [table `((,id ((1 1))))])
   (test `((application-ok (#%app h x))) 


### PR DESCRIPTION
This commit makes all the tests in the current test suite pass. These changes ignore submodules declared with the `module` form, when we should probably recur inside those as well, but that probably makes more sense as a separate change.
