### PR TITLE
Convert to Racket

### DIFF
--- a/no-brainer/info.rkt
+++ b/no-brainer/info.rkt
@@ -1,11 +1,11 @@
-(module info (lib "infotab.ss" "setup")
+(module info setup/infotab
   (define name "No-Brainer")
   (define blurb `("A simple static checker that reports some local arity errors and unused bindings"))
   (define release-notes
     `("This version uses planet2."))
   (define categories `(devtools))
-  (define tools '(("no-brainer-tool.rkt")))
-  (define tool-names (list "Simple Static Checker"))
+  (define drracket-tools '(("no-brainer-tool.rkt")))
+  (define drracket-tool-names (list "Simple Static Checker"))
   (define compile-omit-paths '("private/test.rkt"))
   (define scribblings '(("no-brainer.scrbl" ())))
   (define version "20130227")

--- a/no-brainer/no-brainer-sig.rkt
+++ b/no-brainer/no-brainer-sig.rkt
@@ -1,5 +1,5 @@
-(module no-brainer-sig mzscheme
-  (require (lib "unit.ss"))
+(module no-brainer-sig racket/base
+  (require racket/unit)
   
   (provide no-brainer^
            no-brainer-vc^

--- a/no-brainer/no-brainer-tool.rkt
+++ b/no-brainer/no-brainer-tool.rkt
@@ -1,19 +1,17 @@
-#lang scheme
+#lang racket/base
   
-(require scheme/contract
-         drscheme/tool
-         mred/mred
-         framework/framework
-         (prefix-in frame: framework/framework)
+(require racket/contract
+         drracket/tool
+         racket/gui/base
+         (prefix-in frame: framework)
          mrlib/switchable-button
-         mrlib/bitmap-label
-         scheme/class
-         scheme/list
-         scheme/unit
-         scheme/runtime-path
-         "no-brainer-sig.ss"
-         "private/no-brainer-vc.ss"
-         "private/no-brainer.ss"
+         racket/class
+         racket/list
+         racket/unit
+         racket/runtime-path
+         "no-brainer-sig.rkt"
+         "private/no-brainer-vc.rkt"
+         "private/no-brainer.rkt"
          (lib "my-macros.ss" "stepper" "private"))
   
 (define-runtime-path icon-path "icon.png")
@@ -21,8 +19,8 @@
   (provide tool@)
   
   (define-unit tool@ 
-    (import drscheme:tool^)
-    (export drscheme:tool-exports^)
+    (import drracket:tool^)
+    (export drracket:tool-exports^)
     
     (define (phase1) (void))
     (define (phase2) (void))
@@ -45,9 +43,9 @@
            (lambda (iter)
              (let* ([lang-settings 
                      (frame:preferences:get
-                      (drscheme:language-configuration:get-settings-preferences-symbol))])
-               (drscheme:eval:expand-program
-                (drscheme:language:make-text/pos (get-definitions-text) 
+                      (drracket:language-configuration:get-settings-preferences-symbol))])
+               (drracket:eval:expand-program
+                (drracket:language:make-text/pos (get-definitions-text)
                                                  0
                                                  (send (get-definitions-text)
                                                        last-position)) 
@@ -100,4 +98,4 @@
         (send (get-button-panel) change-children
               (lx (cons no-brainer-button (remq no-brainer-button _))))))
     
-    (drscheme:get/extend:extend-unit-frame debugger-unit-frame-mixin))
+    (drracket:get/extend:extend-unit-frame debugger-unit-frame-mixin))

--- a/no-brainer/private/build-arity-table.rkt
+++ b/no-brainer/private/build-arity-table.rkt
@@ -1,9 +1,8 @@
-(module build-arity-table scheme
+(module build-arity-table racket/base
   
   (require syntax/kerncase
-           (lib "contract.ss")
-           (lib "list.ss")
-           "arity-table.ss")
+           racket/contract
+           "arity-table.rkt")
   
   (provide/contract [build-arity-table (-> syntax? table?)])
   
@@ -162,7 +161,7 @@
   
   (define incr-limit
     (contract 
-     (-> (union number? (symbols 'inf)) any)
+     (-> (or/c number? (symbols 'inf)) any)
      (lambda (limit)
        (cond [(number? limit) (+ 1 limit)]
              [(eq? limit 'inf) 'inf]))

--- a/no-brainer/private/check-program.rkt
+++ b/no-brainer/private/check-program.rkt
@@ -1,9 +1,8 @@
-#lang scheme
+#lang racket/base
   
 (require syntax/kerncase
-         scheme/contract
-         scheme/list
-         "arity-table.ss"
+         racket/contract
+         "arity-table.rkt"
          (lib "shared.ss" "stepper" "private"))
   
   (provide/contract [check-program (-> syntax? table? (listof (cons/c symbol? (cons/c syntax? any/c))))])

--- a/no-brainer/private/no-brainer-vc.rkt
+++ b/no-brainer/private/no-brainer-vc.rkt
@@ -1,9 +1,9 @@
-(module no-brainer-vc mzscheme
-  (require (lib "unit.ss")
-           "../no-brainer-sig.ss"
-           (lib "mred.ss" "mred")
-           (lib "class.ss")
-           (lib "framework.ss" "framework"))
+(module no-brainer-vc racket/base
+  (require racket/unit
+           "../no-brainer-sig.rkt"
+           mred
+           racket/class
+           framework)
   
   (provide no-brainer-vc@)
   

--- a/no-brainer/private/no-brainer.rkt
+++ b/no-brainer/private/no-brainer.rkt
@@ -1,10 +1,10 @@
-(module no-brainer mzscheme
-  (require (lib "unit.ss")
-           "../no-brainer-sig.ss"
-           (lib "match.ss")
-           "build-arity-table.ss"
-           "arity-table.ss"
-           "check-program.ss"
+(module no-brainer racket/base
+  (require racket/unit
+           "../no-brainer-sig.rkt"
+           racket/match
+           "build-arity-table.rkt"
+           "arity-table.rkt"
+           "check-program.rkt"
 	   (lib "my-macros.ss" "stepper" "private"))
   
   (provide no-brainer@)
@@ -72,7 +72,7 @@
       (receive-string
        (apply string-append
               (map (lx (format "defined value ~a from ~a unused in module\n"
-                               (syntax-object->datum _)
+                               (syntax->datum _)
                                _))
                    (list-ref result 3)))))
     

--- a/no-brainer/private/tests.rkt
+++ b/no-brainer/private/tests.rkt
@@ -1,4 +1,4 @@
-#lang scheme
+#lang racket
 
 (require "build-arity-table.rkt"
          "check-program.rkt"


### PR DESCRIPTION
Changes instances of scheme/mzscheme to racket, this commit should also allow no-brainer to be installed as a package.
